### PR TITLE
added xfluo rec start-up option to start xfluo in Command Line Interface mode

### DIFF
--- a/bin/xfluo
+++ b/bin/xfluo
@@ -20,6 +20,9 @@ def init(args):
     else:
         raise RuntimeError("{0} already exists".format(args.config))
 
+def rec(args):
+    from xfluo import reco
+    reco.tomo(args)
 
 def gui(args):
     try:
@@ -38,6 +41,7 @@ def main():
 
     cmd_parsers = [
         ('init',        init,           (),                             "Create configuration file"),
+        ('rec',         rec,            tomo_params,                    "Run tomographic reconstruction using the parameters selected with the GUI"),
         ('gui',         gui,            gui_params,                     "GUI for xfluo tomographic reconstruction"),
     ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,36 +295,5 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #ztexinfo_no_detailmenu = False
 
-# picked from http://read-the-docs.readthedocs.org/en/latest/faq.html
-class Mock(object):
-
-    __all__ = []
-
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __call__(self, *args, **kwargs):
-        return Mock()
-
-    @classmethod
-    def __getattr__(cls, name):
-        return Mock()
-    def __mul__(self, other):
-        return Mock()
-    def __rmul__(self, other):
-        return Mock()
-    def __pow__(self, other):
-        return Mock()
-    def __div__(self, other):
-        return Mock()
-    def __add__(self, other):
-        return Mock()
-    def __radd__(self, other):
-        return Mock()
-
-MOCK_MODULES = ['numpy', 'numpy.ma', 'numpy.random', 'h5py', 'tomopy', 'tomopy.util', 'tomopy.util.dtype',
-                'tifffile', 'dxchange', 'matplotlib', 'matplotlib.pylab', 'matplotlib.pyplot', 'PyQt5', 
-                'PyQt5.QtCore','pyqtgraph', 'glob', 'pylab','sys.path', 'scipy', 'scipy.fftpack']
-
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = Mock()
+# http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports
+autodoc_mock_imports = "numpy h5py tomopy tifffile dxchange matplotlib PyQt5 pyqtgraph glob pylab sys scipy".split()

--- a/xfluo/__init__.py
+++ b/xfluo/__init__.py
@@ -52,6 +52,8 @@ from __future__ import (absolute_import, division, print_function,
 from xfluo.file_io.reader import *
 from xfluo.file_io.writer import *
 
+from xfluo.reco import *
+
 from xfluo.models.element_table import *
 from xfluo.models.file_table import *
 

--- a/xfluo/reco.py
+++ b/xfluo/reco.py
@@ -1,0 +1,22 @@
+import os
+import logging
+import glob
+import tempfile
+import sys
+import numpy as np
+import tomopy
+
+LOG = logging.getLogger(__name__)
+
+def tomo(params):
+
+    # use https://github.com/tomography/ufot/blob/master/ufot/reco.py 
+    # as a template
+    # this module allows for batch reconstruction of multiple data set using
+    # the parameters selected/optimized with the xfluo GUI
+    # to run it use bin/xfluo rec
+    print ("do nothing for now ...")
+
+    rec = True
+
+    return rec

--- a/xfluo/reco.py
+++ b/xfluo/reco.py
@@ -1,8 +1,4 @@
-import os
 import logging
-import glob
-import tempfile
-import sys
 import numpy as np
 import tomopy
 


### PR DESCRIPTION
This pull request adds the "rec" option to bin/xfluo to start xfluo in command line mode allowing to   batch multiple reconstruction using the parameters selected/optimized with the xfluo GUI.

This enable, for example, the possibility to generate with a single command line a series of reconstructions (for example using different iterative or direct inversion methods) using the same alignment parameters and projections/elements  selected in the xfluo GUI.


