### PR TITLE
Fix for issue #19

### DIFF
--- a/xfluo/models/element_table.py
+++ b/xfluo/models/element_table.py
@@ -78,9 +78,9 @@ class ElementTableModel(QtCore.QAbstractTableModel):
     def columnCount(self, parent):
         return len(self.columns)
     # fdc 04/30/2019 commented to fix compile error. Please defing int = ...
-    # def headerData(self, section: int, orientation: QtCore.Qt.Orientation, role: int = ...):
-    #     if role == QtCore.Qt.DisplayRole and orientation == QtCore.Qt.Horizontal:
-    #         return self.columns[section]
+    def headerData(self, section: int, orientation: QtCore.Qt.Orientation, role: int = ...):
+        if role == QtCore.Qt.DisplayRole and orientation == QtCore.Qt.Horizontal:
+            return self.columns[section]
 
     def flags(self, index):
         flags = QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled

--- a/xfluo/models/file_table.py
+++ b/xfluo/models/file_table.py
@@ -100,9 +100,9 @@ class FileTableModel(QtCore.QAbstractTableModel):
         return len(self.columns)
 
     # fdc 04/30/2019 commented to fix compile error. Please defing int = ...
-    # def headerData(self, section: int, orientation: QtCore.Qt.Orientation, role: int = ...):
-    #     if role == QtCore.Qt.DisplayRole and orientation == QtCore.Qt.Horizontal:
-    #         return self.columns[section]
+    def headerData(self, section: int, orientation: QtCore.Qt.Orientation, role: int = ...):
+        if role == QtCore.Qt.DisplayRole and orientation == QtCore.Qt.Horizontal:
+            return self.columns[section]
 
     def flags(self, index):
         flags = QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled


### PR DESCRIPTION
I was able to build the docs with python 3.6.8 sphinx 2.0.1 with the header uncommented.

sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v2.0.1
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 13 source files that are out of date
updating environment: 13 added, 0 changed, 0 removed
checking for /local/aglowacki/src/xfluo/docs/source/bibtex/cite.bib in bibtex cache... not found
parsing bibtex file /local/aglowacki/src/xfluo/docs/source/bibtex/cite.bib... parsed 1 entries
checking for /local/aglowacki/src/xfluo/docs/source/bibtex/ref.bib in bibtex cache... not found
parsing bibtex file /local/aglowacki/src/xfluo/docs/source/bibtex/ref.bib... parsed 1 entries
reading sources... [100%] source/install
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] source/install
generating indices... genindex py-modindex
highlighting module code... [100%] xfluo.reco
writing additional pages... search/local/aglowacki/bin/anaconda3/lib/python3.6/site-packages/sphinx_rtd_theme/search.html:20: RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
  {{ super() }}

copying images... [100%] source/img/create-pr.png
copying downloadable files... [100%] demo/example_01.py
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded.
