### PR TITLE
fix readthedocs API

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -296,7 +296,8 @@ texinfo_documents = [
 #ztexinfo_no_detailmenu = False
 
 # http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports
-autodoc_mock_imports = "cv2 numpy h5py tomopy tifffile dxchange matplotlib PyQt5 pyqtgraph glob pylab sys scipy string PIL time collections configparser argparse".split()
+autodoc_mock_imports = "cv2 numpy h5py tomopy tifffile dxchange matplotlib PyQt5 pyqtgraph glob \
+                        pylab sys scipy string PIL time collections configparser argparse os".split()
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -296,4 +296,9 @@ texinfo_documents = [
 #ztexinfo_no_detailmenu = False
 
 # http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports
-autodoc_mock_imports = "cv2 numpy h5py tomopy tifffile dxchange matplotlib PyQt5 pyqtgraph glob pylab sys scipy".split()
+autodoc_mock_imports = "cv2 numpy h5py tomopy tifffile dxchange matplotlib PyQt5 pyqtgraph glob pylab sys scipy string PIL time collections configparser argparse".split()
+
+
+
+
+


### PR DESCRIPTION
Fixed Mocks so now [docs](https://xfluo.readthedocs.io/en/latest/source/api/xfluo.models.file_table.html) shows function docs